### PR TITLE
Add auto-focus and keyboard controls to note textarea

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,6 +422,14 @@ The component receives an `isAdmin` prop and only renders the "+ Add Note"
 button and note action controls (flag, edit, delete) when `isAdmin` is true.
 Non-admin users can view notes but cannot modify them.
 
+**EditNoteForm behavior:**
+The note textarea automatically receives focus when the form opens (either for
+adding a new note or editing an existing one). The form closes when the user
+presses Escape or when focus moves outside the form entirely (checked via
+`event.relatedTarget`). Pressing Tab moves focus between textarea and buttons
+without closing the form. Buttons use `onMouseDown` preventDefault to prevent
+blur from firing when clicked, ensuring submit works correctly.
+
 A "note" object has the following properties:
  - `ID` (int): the primary identifier for this note
  - `RecipeId` (int): the RecipeId for the recipe this note belongs to
@@ -579,6 +587,8 @@ See TODO.md for a description of bugs to be fixed and features to be added.
  2. Identify relevant files
  3. Explain the current implementation
  4. Propose changes. Do not write code until the user signs-off on the plan
+ 5. Write any spec or implementation documents to the same location as other
+    similar documents that already exist.
 
 
 ##When making changes

--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,6 @@
 # TODO
 This file contains feature or bugfix requests.
 
-## Auto-focus Note Textarea
-When the user clicks "+ Add Note", the textarea in the EditNoteForm should
-automatically receive focus so they can start typing immediately without
-needing to click again.
-
 ## Label Manager Interface
 We should have an interface that, when active, replaces the List Pane and
 Recipe Pane and instead shows all the labels in the system and allows us to

--- a/docs/specs/auto-focus-note-textarea.md
+++ b/docs/specs/auto-focus-note-textarea.md
@@ -1,0 +1,37 @@
+# Auto-focus Note Textarea
+
+## Desired Outcome
+When a user clicks "+ Add Note" or edits a note, the textarea in the EditNoteForm should automatically receive focus, allowing them to start typing immediately without needing to click the textarea. The form should close when the user presses Escape or clicks outside the textarea (blur).
+
+## Current State (Before Implementation)
+The EditNoteForm component (Notes.js:123-136) was a simple functional component that rendered a textarea. When the form opened, the user had to click into the textarea before typing.
+
+## Implementation
+Following the pattern used in TagRecipeForm (Tags.js:84-100):
+
+1. Imported `useRef` and `useEffect` from React at the top of Notes.js
+2. In the `EditNoteForm` component:
+   - Created refs for both the textarea and form using `useRef(null)`
+   - Added a `useEffect` hook with empty dependency array to run on mount
+   - In the effect, check if the ref is set and call `.focus()` on it
+   - Attached the refs to the textarea and form elements
+3. Added keyboard and blur handlers:
+   - `handleBlur` checks if focus is moving outside the form using `event.relatedTarget`. Only closes the form if focus is leaving the form entirely, not when tabbing between textarea and buttons.
+   - `onKeyDown` handler detects Escape key and calls `props.handleCancel` to close the form
+   - `handleButtonMouseDown` prevents default on buttons to prevent blur from firing when clicking them, ensuring submit works correctly
+
+## Design Decisions During Implementation
+- **No text selection**: Initially considered selecting existing text when editing a note (like some text editors do), but decided against it. Users typically want to edit specific parts of a note, not replace the entire content.
+- **Smart blur behavior**: Unlike tags, the form doesn't close when tabbing between textarea and buttons. Only closes when focus leaves the form entirely. This required checking `event.relatedTarget` to see if the new focus target is within the form.
+- **Button mouseDown prevention**: Buttons use `onMouseDown` preventDefault to stop blur from firing when clicking them. This ensures the submit button can actually submit before blur would close the form.
+
+## Key Differences from Tag Form
+The tag form uses a Combobox component from react-widgets, which requires accessing the `inputNode` property. The note form uses a native `<textarea>`, so `.focus()` can be called directly on the ref without setTimeout.
+
+## Testing
+1. Click "+ Add Note" and verify cursor appears in textarea without clicking
+2. Click edit on an existing note and verify cursor appears without clicking
+3. Press Escape and verify form closes
+4. Click outside textarea and verify form closes
+5. Verify submit button still works correctly
+6. Verify cancel button still works correctly

--- a/src/Notes.js
+++ b/src/Notes.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef, useEffect } from "react";
 
 const NoteList = (props) => {
   var notes;
@@ -122,13 +122,55 @@ const NoteActions = (props) => {
 
 const EditNoteForm = (props) => {
   const defaultText = props.note ? props.note.Note : "";
+  const textareaRef = useRef(null);
+  const formRef = useRef(null);
+
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.focus();
+    }
+  }, []);
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      props.handleCancel(event);
+    }
+  };
+
+  // Only close form if focus is moving outside the form
+  const handleBlur = (event) => {
+    // Check if the new focus target is within the form
+    if (formRef.current && !formRef.current.contains(event.relatedTarget)) {
+      props.handleCancel(event);
+    }
+  };
+
+  // Prevent blur from firing when clicking buttons
+  const handleButtonMouseDown = (event) => {
+    event.preventDefault();
+  };
+
   return (
-    <form className="note-edit-form" onSubmit={props.handleSubmit}>
-      <textarea name="text" defaultValue={defaultText} />
-      <button className="textarea-button submit">
+    <form ref={formRef} className="note-edit-form" onSubmit={props.handleSubmit}>
+      <textarea
+        ref={textareaRef}
+        name="text"
+        defaultValue={defaultText}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+      />
+      <button
+        className="textarea-button submit"
+        onMouseDown={handleButtonMouseDown}
+      >
         {String.fromCharCode(0x2713)}
       </button>
-      <button className="textarea-button cancel" onClick={props.handleCancel}>
+      <button
+        className="textarea-button cancel"
+        onClick={props.handleCancel}
+        onMouseDown={handleButtonMouseDown}
+      >
         {String.fromCharCode(0x2717)}
       </button>
     </form>


### PR DESCRIPTION
The note textarea now automatically receives focus when opening the form (for both adding and editing notes). Form closes on Escape key or blur.